### PR TITLE
postbuild file ifdefs out ios

### DIFF
--- a/VologramsToolkit/Scripts/Editor/VolPostBuild.cs
+++ b/VologramsToolkit/Scripts/Editor/VolPostBuild.cs
@@ -7,13 +7,16 @@
 
 using UnityEditor;
 using UnityEditor.Callbacks;
+#if UNITY_IOS
 using UnityEditor.iOS.Xcode;
+#endif // UNITY_IOS
 
 /// <summary>
 /// Class for post Unity-build functions
 /// </summary>
 public class VolPostBuild
 {
+#if UNITY_IOS
     private const string VideoToolbox = "VideoToolbox.framework";
     private const string LibZ = "libz.tbd";
     private const string LibBz2 = "libbz2.tbd";
@@ -55,4 +58,5 @@ public class VolPostBuild
             }
         }
     }
+#endif // UNITY_IOS
 }


### PR DESCRIPTION
Purpose of PR

* During testing of this plugin, building from source, I didn't have iOS added as a build package in my Unity install. That caused errors about invalid build targets when importing the plugin.

Work done in PR

* Lines of code in the postbuild c-sharp code that depended on a Unity iOS install now are if-deffed out if that is not the case.

Testing Summary

* Tested after the change, and the plugin worked and I was able to import and play a vologram on my Windows PC with Unity 2020.3.28 without any support for iOS added.

Risk of Merging PR

* Hopefully this does still work for iOS builds.