### PR TITLE
Always frameskip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 VologramsToolkit/Plugins/*
+UnityVol/Plugins/x64/vol_unity_lib_win.dll
+windows/vol_unity_lib_win/vol_unity_lib_win/vol_unity_lib_win.vcxproj

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 VologramsToolkit/Plugins/*
 UnityVol/Plugins/x64/vol_unity_lib_win.dll
-windows/vol_unity_lib_win/vol_unity_lib_win/vol_unity_lib_win.vcxproj
+*.vcxproj

--- a/VologramsToolkit/Scripts/Player/VolPlayer.cs
+++ b/VologramsToolkit/Scripts/Player/VolPlayer.cs
@@ -124,24 +124,21 @@ public class VolPlayer : MonoBehaviour
             }
             return;
         }
+        // --VIDEO TEXTURE--
         // Always skip video frames to desired frame.
         ReadVideoFrame(_currentFrameIndex, desiredFrameIndex);
-        {
+
+        { // --GEOMETRY--
             int previousKeyframeIndex = VolPluginInterface.VolGeomFindPreviousKeyframe(desiredFrameIndex);
             bool desiredIsKeyframe = VolPluginInterface.VolGeomIsKeyframe(desiredFrameIndex);
             // If our desired frame would jump over its proceeding keyframe, we need to stop and load that first,
             // unless it is a keyframe itself.
-            bool needToLoadKeyframe = (currentFrameIndex < previousKeyframeIndex) && !desiredIsKeyframe;
-
-            string sequenceFile = Path.Combine(_fullGeomPath, "sequence_0.vols");
-            if (!VolPluginInterface.VolGeomReadFrame(sequenceFile, frame))
-            {
-                Debug.LogError("Error loading geometry frame");
-                return;
-            }
+            bool needToLoadKeyframe = (_currentFrameIndex < previousKeyframeIndex) && !desiredIsKeyframe;
             if ( needToLoadKeyframe ) { ReadGeomFrame( previousKeyframeIndex); }
             ReadGeomFrame( desiredFrameIndex);
         }
+        
+        // Advance frame
         _currentFrameIndex = desiredFrameIndex;
     }
 

--- a/VologramsToolkit/Scripts/Player/VolPlayer.cs
+++ b/VologramsToolkit/Scripts/Player/VolPlayer.cs
@@ -40,7 +40,7 @@ public class VolPlayer : MonoBehaviour
     
     private string _fullGeomPath;
     private string _fullVideoPath;
-    private int _frameCount;
+    private int _currentFrameIndex;
     private int _numFrames;
     private bool _hasVideoTexture;
     private float _timeTracker;
@@ -58,7 +58,7 @@ public class VolPlayer : MonoBehaviour
 
     public bool IsOpen { get; private set; }
     public bool IsPlaying { get; private set; }
-    public int Frame => _frameCount;
+    public int Frame => _currentFrameIndex;
     public bool IsMuted => audioOn && _audioPlayer != null && _audioPlayer.GetDirectAudioMute(0);
     
     /// <summary>
@@ -217,7 +217,7 @@ public class VolPlayer : MonoBehaviour
             return false;
         }
 
-        _frameCount = 0;
+        _currentFrameIndex = 0;
         _numFrames = VolPluginInterface.VolGeomGetFrameCount(); 
         _secondsPerFrame = 1f / 30f;
 
@@ -340,13 +340,13 @@ public class VolPlayer : MonoBehaviour
         if (!IsOpen) 
             return;
         
-        if (_isSkipping || frame <= _frameCount)
+        if (_isSkipping || frame <= _currentFrameIndex)
             return;
 
         _isSkipping = true;
         Pause();
 
-        while (_frameCount < frame)
+        while (_currentFrameIndex < frame)
         {
             ReadNextFrame(true);
         }
@@ -396,7 +396,7 @@ public class VolPlayer : MonoBehaviour
             return false;
         }
 
-        _frameCount = 0;
+        _currentFrameIndex = 0;
 
         IsOpen = true;
         if (playOnStart)
@@ -544,7 +544,7 @@ public class VolPlayer : MonoBehaviour
     /// <param name="dispose">True if the read data will be skipped</param>
     private void ReadNextFrame(bool dispose = false)
     {
-        if (_frameCount >= _numFrames)
+        if (_currentFrameIndex >= _numFrames)
             return;
 
         _colorPtr = VolPluginInterface.VolReadNextFrame();
@@ -561,7 +561,7 @@ public class VolPlayer : MonoBehaviour
 #endif
         }
 
-        _frameCount++;
+        _currentFrameIndex++;
     }
 
     /// <summary>

--- a/VologramsToolkit/Scripts/Player/VolPlayer.cs
+++ b/VologramsToolkit/Scripts/Player/VolPlayer.cs
@@ -532,7 +532,7 @@ public class VolPlayer : MonoBehaviour
     }
 
     /// <summary>
-    /// Read a desired geometry and texture frame
+    /// Read a desired texture frame
     /// </summary>
     /// <param name="currentFrameIndex">The frame we last played.</param>
     /// <param name="desiredFrameIndex">The frame we want to retrieve and upload to the current texture.</param>

--- a/VologramsToolkit/Scripts/VolPluginInterface.cs
+++ b/VologramsToolkit/Scripts/VolPluginInterface.cs
@@ -93,9 +93,6 @@ public class VolPluginInterface
     [DllImport(DLL, EntryPoint = "native_vol_geom_find_previous_keyframe")]
     public static extern int VolGeomFindPreviousKeyframe(int frame);
 
-    [DllImport(DLL, EntryPoint = "native_vol_get_next_geom_frame_index")]
-    public static extern int VolGeomGetNextFrameIndex();
-
     [DllImport(DLL, EntryPoint = "native_vol_get_geom_ptr_data")]
     public static extern VolGeometryData VolGeomGetPtrData();
 

--- a/VologramsToolkit/Scripts/VolPluginInterface.cs
+++ b/VologramsToolkit/Scripts/VolPluginInterface.cs
@@ -122,7 +122,7 @@ public class VolPluginInterface
     public static extern long VolGetFrameSize();
 
     [DllImport(DLL, EntryPoint = "native_vol_read_next_frame")]
-    public static extern IntPtr VolReadNextFrame();
+    public static extern IntPtr VolReadNextFrame(bool flipVertical);
 
     //[DllImport(DLL, EntryPoint = "get_texture_update_callback")]
     //private static extern System.IntPtr GetTextureUpdateCallback();

--- a/VologramsToolkit/Scripts/VolPluginInterface.cs
+++ b/VologramsToolkit/Scripts/VolPluginInterface.cs
@@ -83,12 +83,15 @@ public class VolPluginInterface
 
     [DllImport(DLL, EntryPoint = "native_vol_get_geom_frame_count")]
     public static extern int VolGeomGetFrameCount();
-
-    [DllImport(DLL, EntryPoint = "native_vol_read_next_geom_frame")]
-    public static extern bool VolGeomReadNextFrame(string sequenceFile);
     
     [DllImport(DLL, EntryPoint = "native_vol_read_geom_frame")]
     public static extern bool VolGeomReadFrame(string sequenceFile, int frame);
+
+    [DllImport(DLL, EntryPoint = "native_vol_geom_is_keyframe")]
+    public static extern bool VolGeomIsKeyframe(int frame);
+
+    [DllImport(DLL, EntryPoint = "native_vol_geom_find_previous_keyframe")]
+    public static extern int VolGeomFindPreviousKeyframe(int frame);
 
     [DllImport(DLL, EntryPoint = "native_vol_get_next_geom_frame_index")]
     public static extern int VolGeomGetNextFrameIndex();
@@ -121,8 +124,8 @@ public class VolPluginInterface
     [DllImport(DLL, EntryPoint = "native_vol_get_video_frame_size")]
     public static extern long VolGetFrameSize();
 
-    [DllImport(DLL, EntryPoint = "native_vol_read_next_frame")]
-    public static extern IntPtr VolReadNextFrame(bool flipVertical);
+    [DllImport(DLL, EntryPoint = "native_vol_read_next_video_frame")]
+    public static extern IntPtr VolReadNextVideoFrame(bool flipVertical);
 
     //[DllImport(DLL, EntryPoint = "get_texture_update_callback")]
     //private static extern System.IntPtr GetTextureUpdateCallback();

--- a/shared/src/vol_interface.c
+++ b/shared/src/vol_interface.c
@@ -374,10 +374,10 @@ static void _image_flip_vertical( uint8_t* bytes_ptr, int width, int height, int
 /** Read the next frame of the video
  @returns   Pointer to the video frame pixel data
  */
-DllExport uint8_t * native_vol_read_next_frame(void)
+DllExport uint8_t * native_vol_read_next_frame( bool flip_vertical )
 {
     vol_av_read_next_frame( &video_file_ptr );
-    _image_flip_vertical(video_file_ptr.pixels_ptr, vid_w, vid_h, 3);
+    if ( flip_vertical ) { _image_flip_vertical(video_file_ptr.pixels_ptr, vid_w, vid_h, 3); }
     return video_file_ptr.pixels_ptr;
 }
     


### PR DESCRIPTION
**Reason for PR**

* For slower devices (e.g. Android mobile) 30fps 2k textures can be very slow.
* I noticed some opportunities to frame-skip by calculating the current frame in the Unity player code, based on elapsed animation time, and not by incremental frame steps.
* Therefore this PR supports frameskip as a default behaviour in playback, not just when it goes very out of sync.

**Changes in this PR**

* Remove the `readnextframe` functions, and replace with `readframe(index)` functions.
* Added frameskip code (requires working out if preceding keyframe was skipped and loading that first) to geometry update code.
* Added `getkeyframe()` functions to plugin interface.
* Moved some frame counting logic from glue/interface code into player code.
* Updated the `step()` function to match new code.
* Renamed some variables I found confusing because I'm old, then confused myself with my own renaming from the day prior, and renamed them yet again (sorry).
* Removed some unused variables and code segments.
* Updated gitignore to ignore my windows VS builds (only sorta worked).
* Video code and geometry code should now drop frames as appropriate and always keep up with audio playback.
* .: Removed the frameskip code from the audio callback.

**Testing Summary**

* Tested with the "Jan California" vologram. Works really well.
* Have not tested with audio.
* Have only tested on Windows - phone test will be crucial here.
* **[updated]** tested artifical slowess with `System.Threading.Thread.Sleep(100);` call in update. Seems like frameskip works properly down to ~3fps and stays in sync - but a test with audio will be the proof.

**Risk of Merging PR**

* I'm rusty at C# so I may have messed something up.
* I highlighted some bits to draw attention to:
    * in my OpenGL code I'm able to just not update indices/UVs for non-keyframes but it didn't seem to work here. Surely there is some data upload we don't need to do on those frames - perhaps by not calling `clear()` on the mesh or so? Potential for further performance improvement here.
    * there's a data copy for mesh frames that feels unnecessary - just flagged as something to have another crack at casting a pointer with instead. Future work.
  