### PR TITLE
patch in case vol_av returns 0 fps

### DIFF
--- a/VologramsToolkit/Scripts/Player/VolPlayer.cs
+++ b/VologramsToolkit/Scripts/Player/VolPlayer.cs
@@ -235,6 +235,7 @@ public class VolPlayer : MonoBehaviour
         _animationAccumulatedSeconds = 0f;
         _numFrames = VolPluginInterface.VolGeomGetFrameCount();
         double fps = VolPluginInterface.VolGetFrameRate();
+        if ( 0.0 == fps ) { fps = 30.0; }
         _secondsPerFrame = 1f / fps; // TODO(Anton) -- we should fetch this from vol_av rather than rely on 30fps.
 
         _voloTexture = new Texture2D(


### PR DESCRIPTION
Reason for PR

* My previous PR made a change to grab the fps reported by the video library rather than using hardcoded 30fps.
* After digging through Jira tickets I found a prior issue where on Android devices sometimes this would give invalid responses (0).

Changes in PR

* I just added a check for that and revert to 30fps in case of 0 being reported.

Testing Summary / Risk

* Tested for regression in Windows - worked fine with large vologram with audio/video.
* Have not tested on Android to confirm it avoids issues mentioned in ticket - if the value returned is not 30 but in fact -100 or some other incorrect value then my fix will not work, and we should change it to always use 30fps.
