### PR TITLE
Updated vol_geom for >2gb files support

### DIFF
--- a/VologramsToolkit/Scripts/VolPluginInterface.cs
+++ b/VologramsToolkit/Scripts/VolPluginInterface.cs
@@ -136,19 +136,19 @@ public class VolPluginInterface
         {
             case 0: 
                 if (interfaceLoggingLevel.HasFlag(VolEnums.LoggingLevel.Info))
-                    Debug.Log($"VOL_LIB {debugString}");
+                    Debug.Log($"VOL_LIB [info] {debugString}");
                 break;
             case 1:
                 if (interfaceLoggingLevel.HasFlag(VolEnums.LoggingLevel.Debug))
-                    Debug.Log($"VOL_LIB {debugString}");
+                    Debug.Log($"VOL_LIB [debug] {debugString}");
                 break;
             case 2:
                 if (interfaceLoggingLevel.HasFlag(VolEnums.LoggingLevel.Warning))
-                    Debug.LogWarning($"VOL_LIB {debugString}");
+                    Debug.LogWarning($"VOL_LIB [warning] {debugString}");
                 break;
             case 3:
                 if (interfaceLoggingLevel.HasFlag(VolEnums.LoggingLevel.Error))
-                    Debug.LogError($"VOL_LIB {debugString}");
+                    Debug.LogError($"VOL_LIB [error] {debugString}");
                 break;
             default:
                 Debug.Log(debugString);
@@ -163,19 +163,19 @@ public class VolPluginInterface
         {
             case 0: 
                 if (geomLoggingLevel.HasFlag(VolEnums.LoggingLevel.Info))
-                    Debug.Log($"VOL_GEOM {debugString}");
+                    Debug.Log($"VOL_GEOM [info] {debugString}");
                 break;
             case 1:
                 if (geomLoggingLevel.HasFlag(VolEnums.LoggingLevel.Debug))
-                    Debug.Log($"VOL_GEOM {debugString}");
+                    Debug.Log($"VOL_GEOM [debug] {debugString}");
                 break;
             case 2:
                 if (geomLoggingLevel.HasFlag(VolEnums.LoggingLevel.Warning))
-                    Debug.LogWarning($"VOL_GEOM {debugString}");
+                    Debug.LogWarning($"VOL_GEOM [warning] {debugString}");
                 break;
             case 3:
                 if (geomLoggingLevel.HasFlag(VolEnums.LoggingLevel.Error))
-                    Debug.LogError($"VOL_GEOM {debugString}");
+                    Debug.LogError($"VOL_GEOM [error] {debugString}");
                 break;
             default:
                 Debug.Log(debugString);
@@ -190,19 +190,19 @@ public class VolPluginInterface
         {
             case 0:
                 if (avLoggingLevel.HasFlag(VolEnums.LoggingLevel.Info))
-                    Debug.Log($"VOL_AV {debugString}");
+                    Debug.Log($"VOL_AV [info] {debugString}");
                 break;
             case 1:
                 if (avLoggingLevel.HasFlag(VolEnums.LoggingLevel.Debug))
-                    Debug.Log($"VOL_AV {debugString}");
+                    Debug.Log($"VOL_AV [debug] {debugString}");
                 break;
             case 2:
                 if (avLoggingLevel.HasFlag(VolEnums.LoggingLevel.Warning))
-                    Debug.LogWarning($"VOL_AV {debugString}");
+                    Debug.LogWarning($"VOL_AV [warning] {debugString}");
                 break;
             case 3:
                 if (avLoggingLevel.HasFlag(VolEnums.LoggingLevel.Error))
-                    Debug.LogError($"VOL_AV {debugString}");
+                    Debug.LogError($"VOL_AV [error] {debugString}");
                 break;
             default:
                 Debug.Log(debugString);

--- a/shared/src/vol_geom.c
+++ b/shared/src/vol_geom.c
@@ -3,8 +3,8 @@
  *
  * vol_geom  | .vol Geometry Decoding API
  * --------- | ---------------------
- * Version   | 0.9
- * Authors   | Anton Gerdelan <anton@volograms.com>
+ * Version   | 0.10
+ * Authors   | See matching header file.
  * Copyright | 2021, Volograms (http://volograms.com/)
  * Language  | C99
  * Files     | 2
@@ -13,10 +13,26 @@
 
 #include "vol_geom.h"
 #include <assert.h>
+#include <inttypes.h> // 64-bit printfs (PRId64 for integer, PRIu64 for unsigned int, PRIx64 for hex)
 #include <stdarg.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <sys/stat.h> // Used for reading file sizes.
+#include <sys/types.h>
+
+// NOTE: ftello() and fseeko() are replace ftell(), fseek(), and their Windows equivalents, to support 64-bit indices to >2GB files.
+#ifdef _WIN32
+#define vol_geom_stat64 _stat64
+#define vol_geom_stat64_t __stat64
+#define vol_geom_fseeko _fseeki64
+#define vol_geom_ftello _ftelli64
+#else
+#define vol_geom_stat64 stat
+#define vol_geom_stat64_t stat
+#define vol_geom_fseeko fseeko
+#define vol_geom_ftello ftello
+#endif
 
 #define VOL_GEOM_LOG_STR_MAX_LEN 512 // Careful - this is stored on the stack to be thread and memory-safe so don't make it too large.
 /// File header section size in bytes. Used in sanity checks to test for corrupted files that are below minimum sizes expected.
@@ -54,6 +70,18 @@ typedef struct vol_geom_file_record_t {
   BASIC API
 ******************************************************************************/
 
+/** Helper function to check the actual size of a file on disk.
+ * @param filename Pointer to nul-terminated file path string. Must not be NULL.
+ * @param sz_ptr   Size of the file, in bytes, is written to address pointed to by sz_ptr. Must not be NULL. Not written when returning false.
+ * @return         False on any error, including bad parameters or file not found. Otherwise true on success, where sz_ptr is set.
+ */
+static bool _get_file_sz( const char* filename, vol_geom_size_t* sz_ptr ) {
+  struct vol_geom_stat64_t stbuf;
+  if ( 0 != vol_geom_stat64( filename, &stbuf ) ) { return false; }
+  *sz_ptr = stbuf.st_size;
+  return true;
+}
+
 /** Helper function to read an entire file into an array of bytes within struct pointed to by `fr_ptr`.
  * @warning        This function allocates memory that the caller must manually free after use.
  * @param filename Pointer to nul-terminated file path string. Must not be NULL.
@@ -61,43 +89,26 @@ typedef struct vol_geom_file_record_t {
  * @return         False on any error.
  */
 static bool _read_entire_file( const char* filename, vol_geom_file_record_t* fr_ptr ) {
-  if ( !filename || !fr_ptr ) { return false; }
+  FILE* f_ptr = NULL;
 
-  FILE* f_ptr = fopen( filename, "rb" );
-  if ( !f_ptr ) { return false; }
-  fseek( f_ptr, 0L, SEEK_END );
-  fr_ptr->sz = (vol_geom_size_t)ftell( f_ptr );
-  _vol_loggerf( VOL_GEOM_LOG_TYPE_DEBUG, "Allocating %u bytes for reading file\n", (uint32_t)fr_ptr->sz );
+  if ( !filename || !fr_ptr ) { goto vol_geom_read_entire_file_failed; }
+
+  if ( !_get_file_sz( filename, &fr_ptr->sz ) ) { goto vol_geom_read_entire_file_failed; }
+
+  _vol_loggerf( VOL_GEOM_LOG_TYPE_DEBUG, "Allocating %" PRId64 " bytes for reading file\n", fr_ptr->sz );
   fr_ptr->byte_ptr = malloc( (size_t)fr_ptr->sz );
-  if ( !fr_ptr->byte_ptr ) {
-    fclose( f_ptr );
-    return false;
-  }
-  rewind( f_ptr );
+  if ( !fr_ptr->byte_ptr ) { goto vol_geom_read_entire_file_failed; }
+
+  f_ptr = fopen( filename, "rb" );
+  if ( !f_ptr ) { goto vol_geom_read_entire_file_failed; }
   vol_geom_size_t nr = fread( fr_ptr->byte_ptr, fr_ptr->sz, 1, f_ptr );
+  if ( 1 != nr ) { goto vol_geom_read_entire_file_failed; }
+
   fclose( f_ptr );
-  if ( 1 != nr ) { return false; }
-
   return true;
-}
-
-/** Helper function to check the actual size of a file on disk.
- * @param filename Pointer to nul-terminated file path string. Must not be NULL.
- * @param sz_ptr   Size of the file, in bytes, is written to address pointed to by sz_ptr. Must not be NULL. Not written when returning false.
- * @return         False on any error, including bad parameters or file not found. Otherwise true on success, where sz_ptr is set.
- */
-static bool _get_file_sz( const char* filename, vol_geom_size_t* sz_ptr ) {
-  if ( !filename || !sz_ptr ) { return false; }
-
-  FILE* f_ptr = fopen( filename, "rb" );
-  if ( !f_ptr ) { return false; }
-  {
-    fseek( f_ptr, 0L, SEEK_END );
-    *sz_ptr = (vol_geom_size_t)ftell( f_ptr );
-  }
-  fclose( f_ptr );
-
-  return true;
+vol_geom_read_entire_file_failed:
+  if ( f_ptr ) { fclose( f_ptr ); }
+  return false;
 }
 
 /** Helper function to read Unity-style strings, specified in VOL format, from a loaded file.
@@ -132,41 +143,41 @@ static bool _read_vol_file_hdr( const vol_geom_file_record_t* fr, vol_geom_file_
   if ( !_read_short_str( fr, 0, &hdr->format ) ) { return false; }
   if ( strncmp( "VOLS", hdr->format.bytes, 4 ) != 0 ) { return false; } // format check
   offset += ( hdr->format.sz + 1 );
-  if ( offset + 4 * sizeof( int32_t ) + 3 >= fr->sz ) { return false; } // OOB
+  if ( offset + 4 * (vol_geom_size_t)sizeof( int32_t ) + 3 >= fr->sz ) { return false; } // OOB
   memcpy( &hdr->version, &fr->byte_ptr[offset], sizeof( int32_t ) );
-  offset += sizeof( int32_t );
+  offset += (vol_geom_size_t)sizeof( int32_t );
   if ( hdr->version != 10 && hdr->version != 11 && hdr->version != 12 ) { return false; } // version check
   memcpy( &hdr->compression, &fr->byte_ptr[offset], sizeof( int32_t ) );
-  offset += sizeof( int32_t );
+  offset += (vol_geom_size_t)sizeof( int32_t );
   if ( !_read_short_str( fr, offset, &hdr->mesh_name ) ) { return false; }
   offset += ( hdr->mesh_name.sz + 1 );
-  if ( offset + 2 * sizeof( int32_t ) + 2 >= fr->sz ) { return false; } // OOB
+  if ( offset + 2 * (vol_geom_size_t)sizeof( int32_t ) + 2 >= fr->sz ) { return false; } // OOB
   if ( !_read_short_str( fr, offset, &hdr->material ) ) { return false; }
   offset += ( hdr->material.sz + 1 );
-  if ( offset + 2 * sizeof( int32_t ) + 1 >= fr->sz ) { return false; } // OOB
+  if ( offset + 2 * (vol_geom_size_t)sizeof( int32_t ) + 1 >= fr->sz ) { return false; } // OOB
   if ( !_read_short_str( fr, offset, &hdr->shader ) ) { return false; }
   offset += ( hdr->shader.sz + 1 );
-  if ( offset + 2 * sizeof( int32_t ) >= fr->sz ) { return false; } // OOB
+  if ( offset + 2 * (vol_geom_size_t)sizeof( int32_t ) >= fr->sz ) { return false; } // OOB
   memcpy( &hdr->topology, &fr->byte_ptr[offset], sizeof( int32_t ) );
-  offset += sizeof( int32_t );
+  offset += (vol_geom_size_t)sizeof( int32_t );
   memcpy( &hdr->frame_count, &fr->byte_ptr[offset], sizeof( int32_t ) );
-  offset += sizeof( int32_t );
+  offset += (vol_geom_size_t)sizeof( int32_t );
 
   // parse v11 part of header
   if ( hdr->version < 11 ) {
     *hdr_sz = offset;
     return true;
   }
-  const vol_geom_size_t v11_section_sz = 3 * sizeof( uint16_t ) + 2 * sizeof( uint8_t );
+  const vol_geom_size_t v11_section_sz = (vol_geom_size_t)( 3 * sizeof( uint16_t ) + 2 * sizeof( uint8_t ) );
   if ( offset + v11_section_sz > fr->sz ) { return false; } // OOB
   hdr->normals  = (bool)fr->byte_ptr[offset++];
   hdr->textured = (bool)fr->byte_ptr[offset++];
   memcpy( &hdr->texture_width, &fr->byte_ptr[offset], sizeof( uint16_t ) );
-  offset += sizeof( uint16_t );
+  offset += (vol_geom_size_t)sizeof( uint16_t );
   memcpy( &hdr->texture_height, &fr->byte_ptr[offset], sizeof( uint16_t ) );
-  offset += sizeof( uint16_t );
+  offset += (vol_geom_size_t)sizeof( uint16_t );
   memcpy( &hdr->texture_format, &fr->byte_ptr[offset], sizeof( uint16_t ) );
-  offset += sizeof( uint16_t );
+  offset += (vol_geom_size_t)sizeof( uint16_t );
 
   // parse v12 part of header
   if ( hdr->version < 12 ) {
@@ -202,20 +213,26 @@ static bool _read_vol_frame( const vol_geom_info_t* info_ptr, int frame_idx, vol
     vol_geom_size_t curr_offset = 0;
 
     { // vertices
-      if ( frame_data_ptr->block_data_sz < ( curr_offset + sizeof( int32_t ) + (vol_geom_size_t)frame_data_ptr->vertices_sz ) ) { return false; }
+      if ( frame_data_ptr->block_data_sz < ( curr_offset + (vol_geom_size_t)sizeof( int32_t ) + (vol_geom_size_t)frame_data_ptr->vertices_sz ) ) {
+        return false;
+      }
 
       memcpy( &frame_data_ptr->vertices_sz, &frame_data_ptr->block_data_ptr[curr_offset], sizeof( int32_t ) );
-      curr_offset += sizeof( int32_t );
+      if ( frame_data_ptr->vertices_sz < 0 ) { return false; }
+      curr_offset += (vol_geom_size_t)sizeof( int32_t );
       frame_data_ptr->vertices_offset = curr_offset;
       curr_offset += (vol_geom_size_t)frame_data_ptr->vertices_sz;
     }
 
     // normals
     if ( info_ptr->hdr.normals && info_ptr->hdr.version >= 11 ) {
-      if ( frame_data_ptr->block_data_sz < ( curr_offset + sizeof( int32_t ) + (vol_geom_size_t)frame_data_ptr->normals_sz ) ) { return false; }
+      if ( frame_data_ptr->block_data_sz < ( curr_offset + (vol_geom_size_t)sizeof( int32_t ) + (vol_geom_size_t)frame_data_ptr->normals_sz ) ) {
+        return false;
+      }
 
       memcpy( &frame_data_ptr->normals_sz, &frame_data_ptr->block_data_ptr[curr_offset], sizeof( int32_t ) );
-      curr_offset += sizeof( int32_t );
+      if ( frame_data_ptr->normals_sz < 0 ) { return false; }
+      curr_offset += (vol_geom_size_t)sizeof( int32_t );
       frame_data_ptr->normals_offset = curr_offset;
       curr_offset += (vol_geom_size_t)frame_data_ptr->normals_sz;
     }
@@ -223,19 +240,23 @@ static bool _read_vol_frame( const vol_geom_info_t* info_ptr, int frame_idx, vol
     // indices and UVs
     if ( info_ptr->frame_headers_ptr[frame_idx].keyframe == 1 || ( info_ptr->hdr.version >= 12 && info_ptr->frame_headers_ptr[frame_idx].keyframe == 2 ) ) {
       { // indices
-        if ( frame_data_ptr->block_data_sz < ( curr_offset + sizeof( int32_t ) + (vol_geom_size_t)frame_data_ptr->indices_sz ) ) { return false; }
+        if ( frame_data_ptr->block_data_sz < ( curr_offset + (vol_geom_size_t)sizeof( int32_t ) + (vol_geom_size_t)frame_data_ptr->indices_sz ) ) {
+          return false;
+        }
 
         memcpy( &frame_data_ptr->indices_sz, &frame_data_ptr->block_data_ptr[curr_offset], sizeof( int32_t ) );
-        curr_offset += sizeof( int32_t );
+        if ( frame_data_ptr->indices_sz < 0 ) { return false; }
+        curr_offset += (vol_geom_size_t)sizeof( int32_t );
         frame_data_ptr->indices_offset = curr_offset;
         curr_offset += (vol_geom_size_t)frame_data_ptr->indices_sz;
       }
 
       { // UVs
-        if ( frame_data_ptr->block_data_sz < ( curr_offset + sizeof( int32_t ) + (vol_geom_size_t)frame_data_ptr->uvs_sz ) ) { return false; }
+        if ( frame_data_ptr->block_data_sz < ( curr_offset + (vol_geom_size_t)sizeof( int32_t ) + (vol_geom_size_t)frame_data_ptr->uvs_sz ) ) { return false; }
 
         memcpy( &frame_data_ptr->uvs_sz, &frame_data_ptr->block_data_ptr[curr_offset], sizeof( int32_t ) );
-        curr_offset += sizeof( int32_t );
+        if ( frame_data_ptr->uvs_sz < 0 ) { return false; }
+        curr_offset += (vol_geom_size_t)sizeof( int32_t );
         frame_data_ptr->uvs_offset = curr_offset;
         curr_offset += (vol_geom_size_t)frame_data_ptr->uvs_sz;
       }
@@ -244,10 +265,13 @@ static bool _read_vol_frame( const vol_geom_info_t* info_ptr, int frame_idx, vol
     // texture
     // NOTE(Anton) not tested since we aren't using embedded textures at the moment.
     if ( info_ptr->hdr.version >= 11 && info_ptr->hdr.textured ) {
-      if ( frame_data_ptr->block_data_sz < ( curr_offset + sizeof( int32_t ) + (vol_geom_size_t)frame_data_ptr->texture_sz ) ) { return false; }
+      if ( frame_data_ptr->block_data_sz < ( curr_offset + (vol_geom_size_t)sizeof( int32_t ) + (vol_geom_size_t)frame_data_ptr->texture_sz ) ) {
+        return false;
+      }
 
       memcpy( &frame_data_ptr->texture_sz, &frame_data_ptr->block_data_ptr[curr_offset], sizeof( int32_t ) );
-      curr_offset += sizeof( int32_t );
+      if ( frame_data_ptr->texture_sz < 0 ) { return false; }
+      curr_offset += (vol_geom_size_t)sizeof( int32_t );
       frame_data_ptr->texture_offset = curr_offset;
       curr_offset += (vol_geom_size_t)frame_data_ptr->texture_sz;
     }
@@ -281,7 +305,8 @@ bool vol_geom_read_frame( const char* seq_filename, const vol_geom_info_t* info_
   }
 
   if ( info_ptr->biggest_frame_blob_sz < total_sz ) {
-    _vol_loggerf( VOL_GEOM_LOG_TYPE_ERROR, "ERROR: pre-allocated frame blob was too small for frame %i: %u/%u bytes.\n", frame_idx, info_ptr->biggest_frame_blob_sz, total_sz );
+    _vol_loggerf( VOL_GEOM_LOG_TYPE_ERROR, "ERROR: pre-allocated frame blob was too small for frame %i: %" PRId64 "/%" PRId64 " bytes.\n", frame_idx,
+      info_ptr->biggest_frame_blob_sz, total_sz );
     return false;
   }
 
@@ -296,7 +321,7 @@ bool vol_geom_read_frame( const char* seq_filename, const vol_geom_info_t* info_
       _vol_loggerf( VOL_GEOM_LOG_TYPE_ERROR, "ERROR could not open file `%s` for frame data.\n", seq_filename );
       return false;
     }
-    if ( -1 == fseek( f_ptr, (long)offset_sz, SEEK_SET ) ) {
+    if ( 0 != vol_geom_fseeko( f_ptr, offset_sz, SEEK_SET ) ) {
       _vol_loggerf( VOL_GEOM_LOG_TYPE_ERROR, "ERROR seeking frame %i from sequence file - file too small for data\n", frame_idx );
       fclose( f_ptr );
       return false;
@@ -334,12 +359,12 @@ bool vol_geom_create_file_info( const char* hdr_filename, const char* seq_filena
       free( record.byte_ptr );
       record.byte_ptr = NULL; // this is checked later, so make = NULL
     }
-    _vol_loggerf( VOL_GEOM_LOG_TYPE_DEBUG, "hdr sz was %u. %u bytes in file\n", (uint32_t)hdr_sz, (uint32_t)record.sz );
+    _vol_loggerf( VOL_GEOM_LOG_TYPE_DEBUG, "hdr sz was %" PRId64 ". %" PRId64 " bytes in file\n", hdr_sz, record.sz );
   }
 
   { // allocate memory for frame headers and frames directory
     vol_geom_size_t frame_headers_sz = info_ptr->hdr.frame_count * sizeof( vol_geom_frame_hdr_t );
-    _vol_loggerf( VOL_GEOM_LOG_TYPE_DEBUG, "Allocating %u bytes for frame headers.\n", (unsigned int)frame_headers_sz );
+    _vol_loggerf( VOL_GEOM_LOG_TYPE_DEBUG, "Allocating %" PRId64 " bytes for frame headers.\n", frame_headers_sz );
     info_ptr->frame_headers_ptr = calloc( 1, (size_t)frame_headers_sz );
     if ( !info_ptr->frame_headers_ptr ) {
       _vol_loggerf( VOL_GEOM_LOG_TYPE_ERROR, "ERROR: OOM allocating frames headers\n" );
@@ -347,7 +372,7 @@ bool vol_geom_create_file_info( const char* hdr_filename, const char* seq_filena
     }
 
     vol_geom_size_t frames_directory_sz = info_ptr->hdr.frame_count * sizeof( vol_geom_frame_directory_entry_t );
-    _vol_loggerf( VOL_GEOM_LOG_TYPE_DEBUG, "Allocating %u bytes for frames directory.\n", (unsigned int)frames_directory_sz );
+    _vol_loggerf( VOL_GEOM_LOG_TYPE_DEBUG, "Allocating %" PRId64 " bytes for frames directory.\n", frames_directory_sz );
     info_ptr->frames_directory_ptr = calloc( 1, (size_t)frames_directory_sz );
     if ( !info_ptr->frames_directory_ptr ) {
       _vol_loggerf( VOL_GEOM_LOG_TYPE_ERROR, "ERROR: OOM allocating frames directory\n" );
@@ -361,6 +386,8 @@ bool vol_geom_create_file_info( const char* hdr_filename, const char* seq_filena
   // find out the size and offset of every frame
   { // fetch frame from sequence file
     vol_geom_size_t sequence_file_sz = 0;
+    if ( !_get_file_sz( seq_filename, &sequence_file_sz ) ) { goto failed_to_read_info; }
+    _vol_loggerf( VOL_GEOM_LOG_TYPE_DEBUG, "Sequence file is %" PRId64 " bytes\n", sequence_file_sz );
 
     f_ptr = fopen( seq_filename, "rb" );
     if ( !f_ptr ) {
@@ -368,18 +395,12 @@ bool vol_geom_create_file_info( const char* hdr_filename, const char* seq_filena
       goto failed_to_read_info;
     }
 
-    { // get file size to do sanity test of other sizes with
-      if ( 0 != fseek( f_ptr, 0L, SEEK_END ) ) { goto failed_to_read_info; }
-      sequence_file_sz = (vol_geom_size_t)ftell( f_ptr );
-      _vol_loggerf( VOL_GEOM_LOG_TYPE_DEBUG, "Sequence file is %u bytes\n", (uint32_t)sequence_file_sz );
-      if ( 0 != fseek( f_ptr, 0L, SEEK_SET ) ) { goto failed_to_read_info; }
-    }
-
     // loop to get each frame's details
     for ( int32_t i = 0; i < info_ptr->hdr.frame_count; i++ ) {
       vol_geom_frame_hdr_t frame_hdr = ( vol_geom_frame_hdr_t ){ .mesh_data_sz = 0 };
 
-      long frame_start_offset = ftell( f_ptr );
+      vol_geom_size_t frame_start_offset = vol_geom_ftello( f_ptr );
+      if ( -1LL == frame_start_offset ) { goto failed_to_read_info; }
 
       if ( !fread( &frame_hdr.frame_number, sizeof( int32_t ), 1, f_ptr ) ) {
         _vol_loggerf( VOL_GEOM_LOG_TYPE_ERROR, "ERROR: frame_number at frame %i in sequence file was out of file size range\n", i );
@@ -394,7 +415,8 @@ bool vol_geom_create_file_info( const char* hdr_filename, const char* seq_filena
         goto failed_to_read_info;
       }
       if ( frame_hdr.mesh_data_sz < 0 || (vol_geom_size_t)frame_hdr.mesh_data_sz > sequence_file_sz ) {
-        _vol_loggerf( VOL_GEOM_LOG_TYPE_ERROR, "ERROR: mesh_data_sz %i was invalid for a sequence of %u bytes\n", frame_hdr.mesh_data_sz, (uint32_t)sequence_file_sz );
+        _vol_loggerf( VOL_GEOM_LOG_TYPE_ERROR, "ERROR: frame %i has mesh_data_sz %i, which is invalid. Sequence file is %" PRId64 " bytes\n", i,
+          frame_hdr.mesh_data_sz, sequence_file_sz );
         goto failed_to_read_info;
       }
       if ( !fread( &frame_hdr.keyframe, sizeof( uint8_t ), 1, f_ptr ) ) {
@@ -402,7 +424,8 @@ bool vol_geom_create_file_info( const char* hdr_filename, const char* seq_filena
         goto failed_to_read_info;
       }
 
-      long frame_current_offset                = ftell( f_ptr );
+      vol_geom_size_t frame_current_offset = vol_geom_ftello( f_ptr );
+      if ( -1LL == frame_current_offset ) { goto failed_to_read_info; }
       info_ptr->frames_directory_ptr[i].hdr_sz = (vol_geom_size_t)frame_current_offset - (vol_geom_size_t)frame_start_offset;
 
       // in version 12 mesh_data_sz includes array sizes, but earlier versions need to add that to payload size
@@ -421,25 +444,26 @@ bool vol_geom_create_file_info( const char* hdr_filename, const char* seq_filena
         }
       }
       if ( info_ptr->frames_directory_ptr[i].corrected_payload_sz > sequence_file_sz ) {
-        _vol_loggerf( VOL_GEOM_LOG_TYPE_ERROR, "ERROR: frame %i corrected_payload_sz %i bytes was too large for a sequence of %u bytes\n", i,
-          info_ptr->frames_directory_ptr[i].corrected_payload_sz, (uint32_t)sequence_file_sz );
+        _vol_loggerf( VOL_GEOM_LOG_TYPE_ERROR, "ERROR: frame %i corrected_payload_sz %" PRId64 " bytes was too large for a sequence of %" PRId64 " bytes\n", i,
+          info_ptr->frames_directory_ptr[i].corrected_payload_sz, sequence_file_sz );
         goto failed_to_read_info;
       }
 
       // seek past mesh data and past the final integer "frame data size". see if file is big enough
-      if ( -1 == fseek( f_ptr, (long)info_ptr->frames_directory_ptr[i].corrected_payload_sz + 4, SEEK_CUR ) ) {
+      if ( 0 != vol_geom_fseeko( f_ptr, info_ptr->frames_directory_ptr[i].corrected_payload_sz + 4, SEEK_CUR ) ) {
         _vol_loggerf( VOL_GEOM_LOG_TYPE_ERROR, "ERROR: not enough memory in sequence file for frame %i contents\n", i );
         goto failed_to_read_info;
       }
-      frame_current_offset = ftell( f_ptr );
+      frame_current_offset = vol_geom_ftello( f_ptr );
+      if ( -1LL == frame_current_offset ) { goto failed_to_read_info; }
 
       // update frame directory and store frame header
       info_ptr->frames_directory_ptr[i].offset_sz = (vol_geom_size_t)frame_start_offset;
       info_ptr->frames_directory_ptr[i].total_sz  = (vol_geom_size_t)frame_current_offset - (vol_geom_size_t)frame_start_offset;
       info_ptr->frame_headers_ptr[i]              = frame_hdr;
       if ( info_ptr->frames_directory_ptr[i].total_sz > sequence_file_sz ) {
-        _vol_loggerf( VOL_GEOM_LOG_TYPE_ERROR, "ERROR: frame %i total_sz %i bytes was too large for a sequence of %u bytes\n", i,
-          info_ptr->frames_directory_ptr[i].total_sz, (uint32_t)sequence_file_sz );
+        _vol_loggerf( VOL_GEOM_LOG_TYPE_ERROR, "ERROR: frame %i total_sz %" PRId64 " bytes was too large for a sequence of %" PRId64 " bytes\n", i,
+          info_ptr->frames_directory_ptr[i].total_sz, sequence_file_sz );
         goto failed_to_read_info;
       }
 
@@ -452,9 +476,9 @@ bool vol_geom_create_file_info( const char* hdr_filename, const char* seq_filena
     f_ptr = NULL; // this is checked later, so make = NULL
   }
 
-  _vol_loggerf( VOL_GEOM_LOG_TYPE_DEBUG, "Allocating preallocated_frame_blob_ptr bytes %u (frame %i)\n", (uint32_t)info_ptr->biggest_frame_blob_sz, biggest_frame_idx );
+  _vol_loggerf( VOL_GEOM_LOG_TYPE_DEBUG, "Allocating preallocated_frame_blob_ptr bytes %" PRId64 " (frame %i)\n", info_ptr->biggest_frame_blob_sz, biggest_frame_idx );
   if ( info_ptr->biggest_frame_blob_sz >= 1024 * 1024 * 1024 ) {
-    _vol_loggerf( VOL_GEOM_LOG_TYPE_ERROR, "ERROR: extremely high frame size %u reported - assuming error.\n", (uint32_t)info_ptr->biggest_frame_blob_sz );
+    _vol_loggerf( VOL_GEOM_LOG_TYPE_ERROR, "ERROR: extremely high frame size %" PRId64 " reported - assuming error.\n", info_ptr->biggest_frame_blob_sz );
     goto failed_to_read_info;
   }
   info_ptr->preallocated_frame_blob_ptr = calloc( 1, info_ptr->biggest_frame_blob_sz );

--- a/shared/src/vol_geom.h
+++ b/shared/src/vol_geom.h
@@ -3,8 +3,9 @@
  *
  * vol_geom  | .vol Geometry Decoding API
  * --------- | ---------------------
- * Version   | 0.9
- * Authors   | Anton Gerdelan <anton@volograms.com>
+ * Version   | 0.10
+ * Authors   | Anton Gerdelan     <anton@volograms.com>
+ *           | Patrick Geoghegan  <patrick@volograms.com>
  * Copyright | 2021, Volograms (http://volograms.com/)
  * Language  | C99
  * Files     | 2
@@ -12,7 +13,6 @@
  *
  * Core library code that reads geometry data for a VOL sequence.
  * These functions are to be built into an application/engine and called from engine code.
- * File format spec: https://volograms.atlassian.net/wiki/spaces/PL/pages/105676833/VOLS+File+Format
  *
  * Eventually
  * ----------
@@ -21,17 +21,18 @@
  *
  * History
  * -------
- * - 0.9.0 (2022/03/22) - Version bump for parity with vol_av.
- * - 0.7.1 (2021/01/24) - New option streaming_mode paramter to vol_geom_create_file_info().
+ * - 0.10.0 (2022/03/22) - Support added for reading >2GB volograms.
+ * - 0.9.0  (2022/03/22) - Version bump for parity with vol_av.
+ * - 0.7.1  (2021/01/24) - New option streaming_mode paramter to vol_geom_create_file_info().
  *                        Set to false for typical phone captures to pre-load the sequence file to reduce disk I/O at run-time.
- * - 0.7.0 (2021/01/20) - Added customisable debug callback.
- * - 0.6.1 (2021/11/25) - Patched 0.6 to add file memory size validation vulnerabilities reported by fuzzer.
- * - 0.6   (2021/11/24) - Better memory allocation and management - improved performance & simpler API should reduce risk of accidental memory leaks.
- * - 0.5   (2021/11/15) - Better platform consistency with specified byte-size type.
- * - 0.4   (2021/10/15) - Updated licence and copyright information.
- * - 0.3   (2021/08/25) - Moved some assertions out and into test program.
- * - 0.2   (2021/08/23) - Added declspec API exports, prefixed types and function names properly with vol_geom_
- * - 0.1.1              - Renamed from vol_read to vol_geom.
+ * - 0.7.0  (2021/01/20) - Added customisable debug callback.
+ * - 0.6.1  (2021/11/25) - Patched 0.6 to add file memory size validation vulnerabilities reported by fuzzer.
+ * - 0.6    (2021/11/24) - Better memory allocation and management - improved performance & simpler API should reduce risk of accidental memory leaks.
+ * - 0.5    (2021/11/15) - Better platform consistency with specified byte-size type.
+ * - 0.4    (2021/10/15) - Updated licence and copyright information.
+ * - 0.3    (2021/08/25) - Moved some assertions out and into test program.
+ * - 0.2    (2021/08/23) - Added declspec API exports, prefixed types and function names properly with vol_geom_
+ * - 0.1.1               - Renamed from vol_read to vol_geom.
  */
 
 #pragma once
@@ -52,7 +53,7 @@ extern "C" {
 #include <stdint.h>
 
 /** Using a specified-size type instead of size_t for better platform consistency. */
-typedef uint64_t vol_geom_size_t;
+typedef int64_t vol_geom_size_t; // Note that signed int64 should be compatible with off_t.
 
 /** Helper struct to store Unity-style strings from VOL file. */
 VOL_GEOM_EXPORT typedef struct vol_geom_short_str_t {

--- a/shared/src/vol_geom.h
+++ b/shared/src/vol_geom.h
@@ -3,7 +3,7 @@
  *
  * vol_geom  | .vol Geometry Decoding API
  * --------- | ---------------------
- * Version   | 0.10
+ * Version   | 0.10.1
  * Authors   | Anton Gerdelan     <anton@volograms.com>
  *           | Patrick Geoghegan  <patrick@volograms.com>
  * Copyright | 2021, Volograms (http://volograms.com/)
@@ -21,6 +21,7 @@
  *
  * History
  * -------
+ * - 0.10.1 (2022/03/31) - More verbose file reading error logs.
  * - 0.10.0 (2022/03/22) - Support added for reading >2GB volograms.
  * - 0.9.0  (2022/03/22) - Version bump for parity with vol_av.
  * - 0.7.1  (2021/01/24) - New option streaming_mode paramter to vol_geom_create_file_info().


### PR DESCRIPTION
### Purpose of PR

* #20 
* Very long studio captures produce files > 2GB ( we have a 6GB and an 8GB sequence file for 2 partner captures ).
* These were rejected by this plugin, but not by the earlier desktop player. 
* The reason for the failure to load was the underlying vol_libs https://github.com/Volograms/vol_libs used in this software was using systems functions (ftell/fseek etc) that were using 32-bit offsets on some platforms, which can at maximum address 2GB of data.

### Work Done in PR

* Updated the vol_libs code in this repository to use version 0.10 of vol_geom, which should support >2GB files on all platforms.

### Testing Done

* Tested large captures (6GB sd and 8GB hd) on Windows in the Unity editor - working fine, although I note downloads of big files can sometimes incur a renaming (Google Drive) and the expected names are hard-coded (header.vols, sequence_0.vols). So I had to rename them to suit. I will push some more error messages.
* vol_libs was tested independently with >2GB hd and sd samples, and worked without issue on Windows, Ubuntu, and macOS.
* The changes to the vol_libs library were fuzzed during that development, and new bugs were found and fixed, which lowers the risk.
* 
### Need Help Testing

* Changes to the libraries _have not been tested with builds for mobile devices yet_.
* *I will need help testing on macOS, iOS, and potentially Android.*
* Regressions - do your existing captures still load and play correctly?

### Risk of Merging PR

* This is a **high risk** merge because it touches a lot of ongoing partner projects, _and the Volu app_.
* We need to do fairly extensive regression testing before merging this PR.
* We should also clearly tag and release this build, such that we can refer users and partners to an earlier build if we find a post-release regression.
* It's okay to leave this PR open for a while as we test everything, and integrate vol_libs changes in other players, to minimise risk.
* Please note, the 'size' type used in vol_geom has been changed from an unisigned 64-bit integer (compatibility with `size_t`) to a signed 64-bit integer (compatibility with `off_t` used by `ftello()` etc.). This may affect some unity wrapper code but I can't see where yet.

